### PR TITLE
add base zookeeper support 

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -134,7 +134,6 @@ func (c *Client) do() error {
 			}
 		}
 	}
-	return nil
 }
 
 func (c *Client) workerLoop() {

--- a/client/client.go
+++ b/client/client.go
@@ -166,8 +166,9 @@ func (c *Client) do() error {
 				return errors.Trace(err)
 			}
 		case addr := <-c.leaderCh:
+			oldAddr := c.addr
 			c.addr = addr
-			return errors.Errorf("leader change %s -> %s", c.addr, addr)
+			return errors.Errorf("leader change %s -> %s", oldAddr, addr)
 		}
 	}
 }

--- a/client/client.go
+++ b/client/client.go
@@ -102,7 +102,8 @@ func (c *Client) cleanupPending(err error) {
 	}
 
 	// clear request in channel too
-	for i := 0; i < len(c.requests); i++ {
+	length = len(c.requests)
+	for i := 0; i < length; i++ {
 		req := <-c.requests
 		req.MarkDone(nil, err)
 	}
@@ -184,9 +185,11 @@ func (c *Client) workerLoop() {
 		select {
 		case <-time.After(1 * time.Second):
 		case addr := <-c.leaderCh:
+			// If old tso server down, NewConnection will fail and return immediately in do function,
+			// so we must check leader change here.
 			log.Warnf("leader change %s -> %s", c.addr, addr)
 			c.addr = addr
-			// wati sometime to let tso server allow accepting connections
+			// Wati sometime to let tso server allow accepting connections.
 			time.Sleep(1 * time.Second)
 		}
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -189,7 +189,7 @@ func (c *Client) workerLoop() {
 			// so we must check leader change here.
 			log.Warnf("leader change %s -> %s", c.addr, addr)
 			c.addr = addr
-			// Wati sometime to let tso server allow accepting connections.
+			// Wait some time to let tso server allow accepting connections.
 			time.Sleep(1 * time.Second)
 		}
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -48,8 +48,9 @@ func (s *testClientSuite) testStartServer(c *C) {
 	cfg := &server.Config{
 		Addr: "127.0.0.1:0",
 		// use a fake zookeeper
-		ZKAddr:   "",
-		RootPath: "/zk/test_tso",
+		ZKAddr:       "",
+		RootPath:     "/zk/test_tso",
+		SaveInterval: 100,
 	}
 	svr, err := server.NewTimestampOracle(cfg)
 	c.Assert(err, IsNil)

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -7,18 +7,22 @@ import (
 	"github.com/juju/errors"
 )
 
+// RequestHeader is for tso request proto.
 type RequestHeader struct {
 }
 
+// Timestamp is for tso timestamp.
 type Timestamp struct {
 	Physical int64
 	Logical  int64
 }
 
+// Response is for tso reponse proto.
 type Response struct {
 	Timestamp
 }
 
+// Encode encodes repsonse proto into w.
 func (res *Response) Encode(w io.Writer) error {
 	var buf [16]byte
 	binary.BigEndian.PutUint64(buf[0:8], uint64(res.Physical))
@@ -27,6 +31,7 @@ func (res *Response) Encode(w io.Writer) error {
 	return errors.Trace(err)
 }
 
+// Decode decodes reponse proto from r.
 func (res *Response) Decode(r io.Reader) error {
 	var buf [16]byte
 	_, err := io.ReadFull(r, buf[0:16])

--- a/tso-server/main.go
+++ b/tso-server/main.go
@@ -13,13 +13,24 @@ import (
 )
 
 var (
-	addr = flag.String("addr", ":1234", "server listening address")
+	addr     = flag.String("addr", "127.0.0.1:1234", "server listening address")
+	zk       = flag.String("zk", "127.0.0.1:2181", "zookeeper address")
+	rootPath = flag.String("root", "/zk/tso", "tso root path in zookeeper, must have the prefix /zk first")
+	logLevel = flag.String("L", "debug", "log level: info, debug, warn, error, fatal")
 )
 
 func main() {
 	flag.Parse()
 
-	oracle, err := server.NewTimestampOracle(*addr)
+	log.SetLevelByString(*logLevel)
+
+	cfg := &server.Config{
+		Addr:     *addr,
+		ZKAddr:   *zk,
+		RootPath: *rootPath,
+	}
+
+	oracle, err := server.NewTimestampOracle(cfg)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/tso-server/main.go
+++ b/tso-server/main.go
@@ -16,6 +16,7 @@ var (
 	addr     = flag.String("addr", "127.0.0.1:1234", "server listening address")
 	zk       = flag.String("zk", "127.0.0.1:2181", "zookeeper address")
 	rootPath = flag.String("root", "/zk/tso", "tso root path in zookeeper, must have the prefix /zk first")
+	interval = flag.Int64("interval", 2000, "interval milliseconds to save timestamp in zookeeper, default is 2000(ms)")
 	logLevel = flag.String("L", "debug", "log level: info, debug, warn, error, fatal")
 )
 
@@ -25,9 +26,10 @@ func main() {
 	log.SetLevelByString(*logLevel)
 
 	cfg := &server.Config{
-		Addr:     *addr,
-		ZKAddr:   *zk,
-		RootPath: *rootPath,
+		Addr:         *addr,
+		ZKAddr:       *zk,
+		RootPath:     *rootPath,
+		SaveInterval: *interval,
 	}
 
 	oracle, err := server.NewTimestampOracle(cfg)

--- a/tso-server/server/config.go
+++ b/tso-server/server/config.go
@@ -1,0 +1,28 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+// Config is the configuration for timestamp oracle server
+type Config struct {
+	// Timestamp oracle server listen address
+	Addr string
+
+	// zookeeper address, format is zk1,zk2..., split by ,.
+	// if empty, the tso server is just a standalone memory server, and
+	// can't save lastest timestamp, so you may only use empty zk address in test.
+	ZKAddr string
+
+	// root path for saving data in zookeeper, the path must has the magic preifx /zk first,
+	RootPath string
+}

--- a/tso-server/server/config.go
+++ b/tso-server/server/config.go
@@ -25,4 +25,9 @@ type Config struct {
 
 	// root path for saving data in zookeeper, the path must has the magic preifx /zk first,
 	RootPath string
+
+	// SaveInterval is the interval time (ms) to save timestamp in zookeeper.
+	// When the leader begins to run, it first loads the saved timestamp from zookeeper, e.g, T1,
+	// and the leader must guarantee that the next timestamp must be > T1 + 2 * SaveInterval.
+	SaveInterval int64
 }

--- a/tso-server/server/server.go
+++ b/tso-server/server/server.go
@@ -327,13 +327,10 @@ func (t *tsoTask) closeAllConns() {
 	t.tso.closeAllConns()
 
 	// we may close the connection in connCh too
-	for {
-		select {
-		case conn := <-t.connCh:
-			conn.Close()
-		default:
-			return
-		}
+	n := len(t.connCh)
+	for i := 0; i < n; i++ {
+		conn := <-t.connCh
+		conn.Close()
 	}
 }
 

--- a/tso-server/server/server_test.go
+++ b/tso-server/server/server_test.go
@@ -56,9 +56,10 @@ func (s *testServerSuite) SetUpSuite(c *C) {
 	s.zkConn = conn
 
 	cfg := &Config{
-		Addr:     "127.0.0.1:0",
-		ZKAddr:   *testZKAddr,
-		RootPath: "/zk/tso_test",
+		Addr:         "127.0.0.1:0",
+		ZKAddr:       *testZKAddr,
+		RootPath:     "/zk/tso_test",
+		SaveInterval: 100,
 	}
 
 	s.tso = testStartServer(c, cfg)
@@ -117,8 +118,9 @@ func (s *testServerSuite) TestServer(c *C) {
 func (s *testServerSuite) TestFakeZK(c *C) {
 	cfg := &Config{
 		// use 127.0.0.1:0 to listen a unique port.
-		Addr:     "127.0.0.1:0",
-		RootPath: "/zk/tso_test",
+		Addr:         "127.0.0.1:0",
+		RootPath:     "/zk/tso_test",
+		SaveInterval: 100,
 	}
 	tso := testStartServer(c, cfg)
 	defer tso.Close()

--- a/tso-server/server/servers_test.go
+++ b/tso-server/server/servers_test.go
@@ -1,0 +1,194 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"encoding/json"
+	"math/rand"
+	"net"
+	"path"
+	"sync"
+	"time"
+
+	"github.com/ngaut/go-zookeeper/zk"
+	"github.com/ngaut/log"
+	"github.com/ngaut/tso/proto"
+	"github.com/ngaut/zkhelper"
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testMultiServerSuite{})
+
+type testMultiServerSuite struct {
+	rootPath string
+
+	servers []*TimestampOracle
+
+	zkConn zkhelper.Conn
+}
+
+func (s *testMultiServerSuite) SetUpSuite(c *C) {
+	conn, err := zkhelper.ConnectToZkWithTimeout(*testZKAddr, time.Second)
+	c.Assert(err, IsNil)
+	s.zkConn = conn
+
+	s.rootPath = "/zk/tso_multi_test"
+
+	n := 3
+	s.servers = make([]*TimestampOracle, 0, n)
+	for i := 0; i < n; i++ {
+		cfg := &Config{
+			// use 127.0.0.1:0 to listen a unique port.
+			Addr:     "127.0.0.1:0",
+			ZKAddr:   *testZKAddr,
+			RootPath: s.rootPath,
+		}
+		tso := testStartServer(c, cfg)
+		s.servers = append(s.servers, tso)
+	}
+}
+
+func (s *testMultiServerSuite) TearDownSuite(c *C) {
+	for _, tso := range s.servers {
+		tso.Close()
+	}
+
+	if s.zkConn != nil {
+		err := zkhelper.DeleteRecursive(s.zkConn, s.rootPath, -1)
+		c.Assert(err, IsNil)
+
+		s.zkConn.Close()
+	}
+}
+
+func (s *testMultiServerSuite) testGetTimestamp(c *C, duration time.Duration) {
+	// get leader tso
+	var (
+		addr  string
+		watch <-chan zk.Event
+		err   error
+		data  []byte
+
+		conn net.Conn
+
+		last proto.Response
+
+		begin = time.Now()
+	)
+
+	for {
+		if time.Now().Sub(begin) > duration {
+			break
+		}
+
+		if len(addr) == 0 {
+			data, _, watch, err = s.zkConn.GetW(path.Join(s.rootPath, "leader"))
+			c.Assert(err, IsNil, Commentf("path %s", path.Join(s.rootPath, "leader")))
+
+			var m map[string]interface{}
+			err = json.Unmarshal(data, &m)
+			c.Assert(err, IsNil)
+
+			addr = m["Addr"].(string)
+
+			conn, err = net.Dial("tcp", addr)
+			c.Assert(err, IsNil)
+		}
+
+		_, err = conn.Write([]byte{0x00})
+		if err == nil {
+			var resp proto.Response
+			err = resp.Decode(conn)
+			if err == nil {
+				c.Assert(resp.Physical, GreaterEqual, last.Physical)
+				c.Assert(resp.Logical, Greater, last.Logical)
+			}
+		}
+
+		if err != nil {
+			conn.Close()
+
+			// try connect the closed leader again, must error.
+			conn, err = net.Dial("tcp", addr)
+			if err == nil {
+				conn.Write([]byte{0x00})
+				var resp proto.Response
+				err = resp.Decode(conn)
+				conn.Close()
+			}
+			c.Assert(err, NotNil)
+
+			// leader stop or close, we will wait some time for leader change.
+			select {
+			case <-watch:
+				log.Warnf("leader changed")
+			case <-time.After(500 * time.Millisecond):
+				log.Warnf("wait change timeout, force get leader again")
+			}
+
+			addr = ""
+		}
+	}
+
+	conn.Close()
+}
+
+func (s *testMultiServerSuite) TestMulti(c *C) {
+	var wg sync.WaitGroup
+
+	done := make(chan struct{}, 1)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		ticker := time.NewTicker(300 * time.Millisecond)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				for i, tso := range s.servers {
+					if tso.IsLeader() {
+						log.Warnf("handle leader %s", tso.ListenAddr())
+						if rand.Int()%2 == 0 {
+							// stop tso server
+							tso.zkElector.Interrupt()
+						} else {
+							// restart tso server
+							tso.Close()
+
+							cfg := &Config{
+								// use 127.0.0.1:0 to listen a unique port.
+								Addr:     "127.0.0.1:0",
+								ZKAddr:   *testZKAddr,
+								RootPath: s.rootPath,
+							}
+							s.servers[i] = testStartServer(c, cfg)
+						}
+
+						break
+					}
+				}
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	s.testGetTimestamp(c, 10*time.Second)
+
+	close(done)
+	wg.Wait()
+}

--- a/tso-server/server/servers_test.go
+++ b/tso-server/server/servers_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ngaut/go-zookeeper/zk"
 	"github.com/ngaut/log"
 	"github.com/ngaut/tso/proto"
+	"github.com/ngaut/tso/util"
 	"github.com/ngaut/zkhelper"
 	. "github.com/pingcap/check"
 )
@@ -91,7 +92,7 @@ func (s *testMultiServerSuite) testGetTimestamp(c *C, duration time.Duration) {
 		}
 
 		if len(addr) == 0 {
-			addr, watch, err = GetWatchLeader(s.zkConn, s.rootPath)
+			addr, watch, err = util.GetWatchLeader(s.zkConn, s.rootPath)
 			c.Assert(err, IsNil)
 
 			conn, err = net.Dial("tcp", addr)

--- a/tso-server/server/servers_test.go
+++ b/tso-server/server/servers_test.go
@@ -48,9 +48,10 @@ func (s *testMultiServerSuite) SetUpSuite(c *C) {
 	for i := 0; i < n; i++ {
 		cfg := &Config{
 			// use 127.0.0.1:0 to listen a unique port.
-			Addr:     "127.0.0.1:0",
-			ZKAddr:   *testZKAddr,
-			RootPath: s.rootPath,
+			Addr:         "127.0.0.1:0",
+			ZKAddr:       *testZKAddr,
+			RootPath:     s.rootPath,
+			SaveInterval: 100,
 		}
 		tso := testStartServer(c, cfg)
 		s.servers = append(s.servers, tso)
@@ -162,9 +163,10 @@ func (s *testMultiServerSuite) TestMulti(c *C) {
 
 							cfg := &Config{
 								// use 127.0.0.1:0 to listen a unique port.
-								Addr:     "127.0.0.1:0",
-								ZKAddr:   *testZKAddr,
-								RootPath: s.rootPath,
+								Addr:         "127.0.0.1:0",
+								ZKAddr:       *testZKAddr,
+								RootPath:     s.rootPath,
+								SaveInterval: 100,
 							}
 							s.servers[i] = testStartServer(c, cfg)
 						}

--- a/tso-server/server/util.go
+++ b/tso-server/server/util.go
@@ -41,13 +41,13 @@ func loadTimestamp(conn zkhelper.Conn, rootPath string) (int64, error) {
 
 func saveTimestamp(conn zkhelper.Conn, rootPath string, ts int64) error {
 	var buf [8]byte
-	binary.BigEndian.PutUint64(buf[0:8], uint64(ts))
+	binary.BigEndian.PutUint64(buf[:], uint64(ts))
 
 	tsPath := getTimestampPath(rootPath)
 
-	_, err := conn.Set(tsPath, buf[0:8], -1)
+	_, err := conn.Set(tsPath, buf[:], -1)
 	if zkhelper.ZkErrorEqual(err, zk.ErrNoNode) {
-		_, err = conn.Create(tsPath, buf[0:8], 0, zk.WorldACL(zkhelper.PERM_FILE))
+		_, err = conn.Create(tsPath, buf[:], 0, zk.WorldACL(zkhelper.PERM_FILE))
 	}
 
 	return errors.Trace(err)

--- a/tso-server/server/util.go
+++ b/tso-server/server/util.go
@@ -1,0 +1,81 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"encoding/json"
+	"path"
+
+	"github.com/juju/errors"
+	"github.com/ngaut/go-zookeeper/zk"
+	"github.com/ngaut/zkhelper"
+)
+
+func getLeader(data []byte) (string, error) {
+	m := struct {
+		Addr string `json:"Addr"`
+	}{}
+
+	err := json.Unmarshal(data, &m)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	return m.Addr, nil
+}
+
+// getLeaderPath gets the leader path in zookeeper.
+func getLeaderPath(rootPath string) string {
+	return path.Join(rootPath, "leader")
+}
+
+// func checkLeaderExists(conn zkhelper.Conn) error {
+// 	// the leader node is not ephemeral, so we may meet no any tso server but leader node
+// 	// has the data for last closed tso server.
+// 	// TODO: check children in /candidates, if no child, we will treat it as no leader too.
+
+// 	return nil
+// }
+
+// GetLeaderAddr gets the leader tso address in zookeeper for outer use.
+func GetLeader(conn zkhelper.Conn, rootPath string) (string, error) {
+	data, _, err := conn.Get(getLeaderPath(rootPath))
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	// if err != checkLeaderExists(conn); err != nil {
+	// 	return "", errors.Trace(err)
+	// }
+
+	return getLeader(data)
+}
+
+// GetWatchLeader gets the leader tso address in zookeeper and returns a watcher for leader change.
+func GetWatchLeader(conn zkhelper.Conn, rootPath string) (string, <-chan zk.Event, error) {
+	data, _, watcher, err := conn.GetW(getLeaderPath(rootPath))
+	if err != nil {
+		return "", nil, errors.Trace(err)
+	}
+	addr, err := getLeader(data)
+	if err != nil {
+		return "", nil, errors.Trace(err)
+	}
+
+	// if err != checkLeaderExists(conn); err != nil {
+	// 	return "", errors.Trace(err)
+	// }
+
+	return addr, watcher, nil
+}

--- a/tso-server/server/util.go
+++ b/tso-server/server/util.go
@@ -15,71 +15,12 @@ package server
 
 import (
 	"encoding/binary"
-	"encoding/json"
 	"path"
 
 	"github.com/juju/errors"
 	"github.com/ngaut/go-zookeeper/zk"
 	"github.com/ngaut/zkhelper"
 )
-
-func getLeader(data []byte) (string, error) {
-	m := struct {
-		Addr string `json:"Addr"`
-	}{}
-
-	err := json.Unmarshal(data, &m)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-
-	return m.Addr, nil
-}
-
-// getLeaderPath gets the leader path in zookeeper.
-func getLeaderPath(rootPath string) string {
-	return path.Join(rootPath, "leader")
-}
-
-// func checkLeaderExists(conn zkhelper.Conn) error {
-// 	// the leader node is not ephemeral, so we may meet no any tso server but leader node
-// 	// has the data for last closed tso server.
-// 	// TODO: check children in /candidates, if no child, we will treat it as no leader too.
-
-// 	return nil
-// }
-
-// GetLeaderAddr gets the leader tso address in zookeeper for outer use.
-func GetLeader(conn zkhelper.Conn, rootPath string) (string, error) {
-	data, _, err := conn.Get(getLeaderPath(rootPath))
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-
-	// if err != checkLeaderExists(conn); err != nil {
-	// 	return "", errors.Trace(err)
-	// }
-
-	return getLeader(data)
-}
-
-// GetWatchLeader gets the leader tso address in zookeeper and returns a watcher for leader change.
-func GetWatchLeader(conn zkhelper.Conn, rootPath string) (string, <-chan zk.Event, error) {
-	data, _, watcher, err := conn.GetW(getLeaderPath(rootPath))
-	if err != nil {
-		return "", nil, errors.Trace(err)
-	}
-	addr, err := getLeader(data)
-	if err != nil {
-		return "", nil, errors.Trace(err)
-	}
-
-	// if err != checkLeaderExists(conn); err != nil {
-	// 	return "", errors.Trace(err)
-	// }
-
-	return addr, watcher, nil
-}
 
 func getTimestampPath(rootPath string) string {
 	return path.Join(rootPath, "timestamp")

--- a/tso-server/server/util_test.go
+++ b/tso-server/server/util_test.go
@@ -1,0 +1,92 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/ngaut/go-zookeeper/zk"
+	"github.com/ngaut/zkhelper"
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testUtilSuite{})
+
+type testUtilSuite struct {
+	zkConn zkhelper.Conn
+
+	rootPath string
+}
+
+func (s *testUtilSuite) SetUpSuite(c *C) {
+	conn, err := zkhelper.ConnectToZkWithTimeout(*testZKAddr, time.Second)
+	c.Assert(err, IsNil)
+	s.zkConn = conn
+
+	s.rootPath = "/zk/tso_util_test"
+
+}
+
+func (s *testUtilSuite) TearDownSuite(c *C) {
+	if s.zkConn != nil {
+		err := zkhelper.DeleteRecursive(s.zkConn, s.rootPath, -1)
+		c.Assert(err, IsNil)
+
+		s.zkConn.Close()
+	}
+}
+
+func (s *testUtilSuite) TestLeader(c *C) {
+	conn, err := zkhelper.ConnectToZkWithTimeout(*testZKAddr, time.Second)
+	c.Assert(err, IsNil)
+	defer conn.Close()
+
+	leaderPath := getLeaderPath(s.rootPath)
+	conn.Delete(leaderPath, -1)
+
+	_, err = GetLeader(conn, s.rootPath)
+	c.Assert(err, NotNil)
+
+	_, _, err = GetWatchLeader(conn, s.rootPath)
+	c.Assert(err, NotNil)
+
+	_, err = zkhelper.CreateRecursive(conn, leaderPath, "", 0, zk.WorldACL(zkhelper.PERM_FILE))
+	c.Assert(err, IsNil)
+
+	_, err = GetLeader(conn, s.rootPath)
+	c.Assert(err, NotNil)
+
+	_, _, err = GetWatchLeader(conn, s.rootPath)
+	c.Assert(err, NotNil)
+
+	addr := "127.0.0.1:1234"
+	m := map[string]interface{}{
+		"Addr": addr,
+	}
+
+	data, err := json.Marshal(m)
+	c.Assert(err, IsNil)
+
+	_, err = conn.Set(leaderPath, data, -1)
+	c.Assert(err, IsNil)
+
+	v, err := GetLeader(conn, s.rootPath)
+	c.Assert(err, IsNil)
+	c.Assert(v, Equals, addr)
+
+	v, _, err = GetWatchLeader(conn, s.rootPath)
+	c.Assert(err, IsNil)
+	c.Assert(v, Equals, addr)
+}

--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,81 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"encoding/json"
+	"path"
+
+	"github.com/juju/errors"
+	"github.com/ngaut/go-zookeeper/zk"
+	"github.com/ngaut/zkhelper"
+)
+
+func getLeader(data []byte) (string, error) {
+	m := struct {
+		Addr string `json:"Addr"`
+	}{}
+
+	err := json.Unmarshal(data, &m)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	return m.Addr, nil
+}
+
+// getLeaderPath gets the leader path in zookeeper.
+func getLeaderPath(rootPath string) string {
+	return path.Join(rootPath, "leader")
+}
+
+// func checkLeaderExists(conn zkhelper.Conn) error {
+//  // the leader node is not ephemeral, so we may meet no any tso server but leader node
+//  // has the data for last closed tso server.
+//  // TODO: check children in /candidates, if no child, we will treat it as no leader too.
+
+//  return nil
+// }
+
+// GetLeaderAddr gets the leader tso address in zookeeper for outer use.
+func GetLeader(conn zkhelper.Conn, rootPath string) (string, error) {
+	data, _, err := conn.Get(getLeaderPath(rootPath))
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	// if err != checkLeaderExists(conn); err != nil {
+	//  return "", errors.Trace(err)
+	// }
+
+	return getLeader(data)
+}
+
+// GetWatchLeader gets the leader tso address in zookeeper and returns a watcher for leader change.
+func GetWatchLeader(conn zkhelper.Conn, rootPath string) (string, <-chan zk.Event, error) {
+	data, _, watcher, err := conn.GetW(getLeaderPath(rootPath))
+	if err != nil {
+		return "", nil, errors.Trace(err)
+	}
+	addr, err := getLeader(data)
+	if err != nil {
+		return "", nil, errors.Trace(err)
+	}
+
+	// if err != checkLeaderExists(conn); err != nil {
+	//  return "", errors.Trace(err)
+	// }
+
+	return addr, watcher, nil
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -11,15 +11,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package util
 
 import (
+	"encoding/json"
+	"flag"
+	"testing"
 	"time"
 
 	"github.com/ngaut/go-zookeeper/zk"
 	"github.com/ngaut/zkhelper"
 	. "github.com/pingcap/check"
 )
+
+var testZKAddr = flag.String("zk", "127.0.0.1:2181", "test zookeeper address")
+
+func TestUtil(t *testing.T) {
+	TestingT(t)
+}
 
 var _ = Suite(&testUtilSuite{})
 
@@ -36,8 +45,6 @@ func (s *testUtilSuite) SetUpSuite(c *C) {
 
 	s.rootPath = "/zk/tso_util_test"
 
-	_, err = zkhelper.CreateRecursive(s.zkConn, s.rootPath, "", 0, zk.WorldACL(zkhelper.PERM_DIRECTORY))
-	c.Assert(err, IsNil)
 }
 
 func (s *testUtilSuite) TearDownSuite(c *C) {
@@ -49,31 +56,45 @@ func (s *testUtilSuite) TearDownSuite(c *C) {
 	}
 }
 
-func (s *testUtilSuite) TestTimestamp(c *C) {
+func (s *testUtilSuite) TestLeader(c *C) {
 	conn, err := zkhelper.ConnectToZkWithTimeout(*testZKAddr, time.Second)
 	c.Assert(err, IsNil)
 	defer conn.Close()
 
-	tbl := []int64{
-		1, 100, 1000,
-	}
+	leaderPath := getLeaderPath(s.rootPath)
+	conn.Delete(leaderPath, -1)
 
-	for _, t := range tbl {
-		err = saveTimestamp(conn, s.rootPath, t)
-		c.Assert(err, IsNil)
-
-		n, err := loadTimestamp(conn, s.rootPath)
-		c.Assert(err, IsNil)
-		c.Assert(n, Equals, t)
-	}
-
-	// test error
-	_, err = loadTimestamp(conn, "error_root_path")
+	_, err = GetLeader(conn, s.rootPath)
 	c.Assert(err, NotNil)
 
-	_, err = conn.Set(getTimestampPath(s.rootPath), []byte{}, -1)
+	_, _, err = GetWatchLeader(conn, s.rootPath)
+	c.Assert(err, NotNil)
+
+	_, err = zkhelper.CreateRecursive(conn, leaderPath, "", 0, zk.WorldACL(zkhelper.PERM_FILE))
 	c.Assert(err, IsNil)
 
-	_, err = loadTimestamp(conn, s.rootPath)
+	_, err = GetLeader(conn, s.rootPath)
 	c.Assert(err, NotNil)
+
+	_, _, err = GetWatchLeader(conn, s.rootPath)
+	c.Assert(err, NotNil)
+
+	addr := "127.0.0.1:1234"
+	m := map[string]interface{}{
+		"Addr": addr,
+	}
+
+	data, err := json.Marshal(m)
+	c.Assert(err, IsNil)
+
+	_, err = conn.Set(leaderPath, data, -1)
+	c.Assert(err, IsNil)
+
+	v, err := GetLeader(conn, s.rootPath)
+	c.Assert(err, IsNil)
+	c.Assert(v, Equals, addr)
+
+	v, _, err = GetWatchLeader(conn, s.rootPath)
+	c.Assert(err, IsNil)
+	c.Assert(v, Equals, addr)
 }


### PR DESCRIPTION
TODO:
- [x] use ZElector to select a leader and run the tso service
- [x] if leader down, select another leader to do tso service.  
- [x] save timestamp in zookeeper
- [x] client uses zookeeper to find the leader
- [x] client watches leader changed and do the switching automatically
